### PR TITLE
perf: Load missions files in a separate thread on startup

### DIFF
--- a/CommercialOfferings/MissionData/Mission.cs
+++ b/CommercialOfferings/MissionData/Mission.cs
@@ -389,14 +389,17 @@ namespace CommercialOfferings.MissionData
             return resultNode;
         }
 
-
+        internal static string MissionsDirectory => RmmUtil.GamePath + Path.DirectorySeparatorChar + "GameData";
 
         public static List<Mission> LoadMissions()
         {
+            return LoadMissionsFrom(MissionsDirectory);
+        }
+
+        internal static List<Mission> LoadMissionsFrom(string directory)
+        {
             List<Mission> missions = new List<Mission>();
-
-            LoadMissionsDirectory(RmmUtil.GamePath + Path.DirectorySeparatorChar + "GameData", ref missions);
-
+            LoadMissionsDirectory(directory, ref missions);
             return missions;
         }
 

--- a/CommercialOfferings/RmmMonoBehaviour.cs
+++ b/CommercialOfferings/RmmMonoBehaviour.cs
@@ -94,6 +94,8 @@ namespace CommercialOfferings
 #endif
             //renderGUITermsCondi = false;
             addToolbarButton();
+
+            _routineControl.OnAwake();
         }
 
         void onDestroy()

--- a/CommercialOfferings/RmmUtil.cs
+++ b/CommercialOfferings/RmmUtil.cs
@@ -36,9 +36,16 @@ namespace CommercialOfferings
 {
     public static class RmmUtil
     {
+        static string gamePath = null;
+
         public static string GamePath
         {
-            get { return KSPUtil.ApplicationRootPath; }
+            get
+            {
+                if (gamePath == null)
+                    gamePath = KSPUtil.ApplicationRootPath;
+                return gamePath;
+            }
         }
         public static string CommercialOfferingsPath
         {

--- a/CommercialOfferings/RoutineControl.cs
+++ b/CommercialOfferings/RoutineControl.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace CommercialOfferings
 {
@@ -22,10 +24,32 @@ namespace CommercialOfferings
         private ArrivalWorker _arrivalWorker = null;
         private DepartureWorker _departureWorker = null;
 
+        private Task<List<Mission>> _missionTask = null;
+
+        public void OnAwake()
+        {
+            if (!HighLogic.LoadedSceneIsFlight)
+                return;
+
+            // We start this in Awake so that it gets as much time to run as
+            // possible.
+            var directory = Mission.MissionsDirectory;
+            _missionTask = Task.Run(() => Mission.LoadMissionsFrom(directory));
+        }
+
         public void OnUpdate()
         {
             if (!HighLogic.LoadedSceneIsFlight) { return; }
             if (_nextLogicTime == 0 || _nextLogicTime > Planetarium.GetUniversalTime()) { return; }
+
+            if (_missionTask != null)
+            {
+                if (!_missionTask.IsCompleted)
+                    return;
+                var task = _missionTask;
+                _missionTask = null;
+                _missions = task.Result;
+            }
 
             HandleRoutine();
             HandleRoutineOverviewWindow();


### PR DESCRIPTION
Walking the directory and finding all the missions seems to take about 600ms. By pushing this to a separate thread we can prevent that from affecting overall scene switch times.

This seems to cause LoadMissions to run more slowly (it now takes 2.4s in my profiles) but in practice scene switch hang is longer than that so it is not an issue.